### PR TITLE
Change api

### DIFF
--- a/scanoss_hook/gitlab.py
+++ b/scanoss_hook/gitlab.py
@@ -212,7 +212,7 @@ class GitLabRequestHandler(BaseHTTPRequestHandler):
 
     """
     path = parse.urlparse(self.path).path
-    if re.search("^/api/file_contents/.*", path):
+    if re.search("^/file_contents/.*", path):
       url = self.scanoss_url + path
       headers = {'X-Session': self.scanoss_token}
       r = requests.get(url, headers=headers)

--- a/scanoss_hook/scanner.py
+++ b/scanoss_hook/scanner.py
@@ -39,7 +39,7 @@ class Scanner:
 
   def __init__(self, config):
     self.url = config['scanoss']['url']
-    self.scan_url = "%s/api/scan/direct" % self.url
+    self.scan_url = "%s/scan/direct" % self.url
     self.token = config['scanoss']['token']
     self.badge_ok_url = "%s/static/badge-scanoss-ok.svg" % self.url
     self.badge_failed_url = "%s/static/badge-scanoss-failed.svg" % self.url


### PR DESCRIPTION
Scanoss will update api url from scanoss.com/api to api.scanoss.com - active now.